### PR TITLE
Small fixes for readme and hello triangle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zig Learn OpenGL
 
-[Learn OpenGL](learnopengl.com) tutorials ported to the zig programming language. This repo follows
+[Learn OpenGL](https://learnopengl.com) tutorials ported to the zig programming language. This repo follows
 the chronological order of the website, separating out the same functionality into separate files.
 The repository is intended to serve as a demonstration of how to use OpenGL with zig, both in user
 code, and with the zig build system.

--- a/src/1_2_hello_triangle.zig
+++ b/src/1_2_hello_triangle.zig
@@ -14,7 +14,7 @@ const vertexShaderSource: [:0]const u8 =
     \\void main()
     \\{
     \\   gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0);
-    \\};
+    \\}
 ;
 const fragmentShaderSource: [:0]const u8 =
     \\#version 330 core
@@ -22,7 +22,7 @@ const fragmentShaderSource: [:0]const u8 =
     \\void main()
     \\{
     \\   FragColor = vec4(1.0f, 0.5f, 0.2f, 1.0f);
-    \\};
+    \\}
 ;
 
 pub fn main() void {


### PR DESCRIPTION
* Currently the readme points to https://github.com/cshenton/learnopengl/blob/master/learnopengl.com whereas you probably meant https://learnopengl.com
* The shader sources for hello triangle produce a syntax error due to extra semicolons