### PR TITLE
Port the tutorial to GNU/Linux

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -46,18 +46,18 @@ const Target = struct {
         // Libraries
         exe.linkLibC();
         exe.addLibPath("deps/lib");
-        exe.linkSystemLibrary("glfw3");
 
         // OS specific
         switch (builtin.os.tag) {
             .windows => {
+                exe.linkSystemLibrary("glfw3");
                 exe.linkSystemLibrary("kernel32");
                 exe.linkSystemLibrary("user32");
                 exe.linkSystemLibrary("shell32");
                 exe.linkSystemLibrary("gdi32");
             },
             else => {
-                @compileError("Not supported, contributions welcome.");
+                exe.linkSystemLibrary("glfw");
             },
         }
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,7 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.glfw3
+  ];
+}


### PR DESCRIPTION
Since the source code mentioned that collaborations are welcome, I tried making this work on my NixOS machine. Turns out I had to change the `exe.linkSystemLibrary("glfw3")` to `exe.linkSystemLibrary("glfw")` for non-Windows systems. I cannot test this on Windows myself, hence I just added this to the `switch` statement.

This now works with system GLFW. If someone doesn't want to install GLFW system-wide, there's now also the possibility to use the [Nix package manager](https://nixos.org/features.html) to provide a dev environment that contains GLFW with all its paths set. For instance, `nix-shell --run 'zig build camera'`.